### PR TITLE
Add BridgingType enum for all ERC-type tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 
 # Typechain generated files
 generated-types
+go-bindings

--- a/contracts/handlers/ERC20Handler.sol
+++ b/contracts/handlers/ERC20Handler.sol
@@ -1,40 +1,51 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import "../interfaces/tokens/IERC20MintableBurnable.sol";
-import "../interfaces/handlers/IERC20Handler.sol";
+import {IUSDCType} from "../interfaces/tokens/IUSDCType.sol";
+import {IERC20Handler} from "../interfaces/handlers/IERC20Handler.sol";
+import {IERC20MintableBurnable} from "../interfaces/tokens/IERC20MintableBurnable.sol";
 
+/**
+ * @title ERC20Handler
+ */
 abstract contract ERC20Handler is IERC20Handler {
     using SafeERC20 for IERC20MintableBurnable;
 
+    /**
+     * @inheritdoc IERC20Handler
+     */
     function depositERC20(
         address token_,
         uint256 amount_,
         string calldata receiver_,
         string calldata network_,
-        bool isWrapped_
+        ERC20BridgingType operationType_
     ) external override {
         require(token_ != address(0), "ERC20Handler: zero token");
         require(amount_ > 0, "ERC20Handler: amount is zero");
 
         IERC20MintableBurnable erc20_ = IERC20MintableBurnable(token_);
 
-        if (isWrapped_) {
+        if (operationType_ == ERC20BridgingType.Wrapped) {
             erc20_.burnFrom(msg.sender, amount_);
         } else {
             erc20_.safeTransferFrom(msg.sender, address(this), amount_);
         }
 
-        emit DepositedERC20(token_, amount_, receiver_, network_, isWrapped_);
+        if (operationType_ == ERC20BridgingType.USDCType) {
+            IUSDCType(token_).burn(amount_);
+        }
+
+        emit DepositedERC20(token_, amount_, receiver_, network_, operationType_);
     }
 
     function _withdrawERC20(
         address token_,
         uint256 amount_,
         address receiver_,
-        bool isWrapped_
+        ERC20BridgingType operationType_
     ) internal {
         require(token_ != address(0), "ERC20Handler: zero token");
         require(amount_ > 0, "ERC20Handler: amount is zero");
@@ -42,13 +53,18 @@ abstract contract ERC20Handler is IERC20Handler {
 
         IERC20MintableBurnable erc20_ = IERC20MintableBurnable(token_);
 
-        if (isWrapped_) {
+        if (operationType_ == ERC20BridgingType.Wrapped) {
             erc20_.mintTo(receiver_, amount_);
+        } else if (operationType_ == ERC20BridgingType.USDCType) {
+            IUSDCType(token_).mint(receiver_, amount_);
         } else {
             erc20_.safeTransfer(receiver_, amount_);
         }
     }
 
+    /**
+     * @inheritdoc IERC20Handler
+     */
     function getERC20SignHash(
         address token_,
         uint256 amount_,
@@ -56,7 +72,7 @@ abstract contract ERC20Handler is IERC20Handler {
         bytes32 txHash_,
         uint256 txNonce_,
         uint256 chainId_,
-        bool isWrapped_
+        ERC20BridgingType operationType_
     ) public pure returns (bytes32) {
         return
             keccak256(
@@ -67,7 +83,7 @@ abstract contract ERC20Handler is IERC20Handler {
                     txHash_,
                     txNonce_,
                     chainId_,
-                    isWrapped_
+                    operationType_
                 )
             );
     }

--- a/contracts/handlers/ERC721Handler.sol
+++ b/contracts/handlers/ERC721Handler.sol
@@ -1,30 +1,36 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 
-import "../interfaces/handlers/IERC721Handler.sol";
-import "../interfaces/tokens/IERC721MintableBurnable.sol";
+import {IERC721Handler} from "../interfaces/handlers/IERC721Handler.sol";
+import {IERC721MintableBurnable} from "../interfaces/tokens/IERC721MintableBurnable.sol";
 
+/**
+ * @title ERC721Handler
+ */
 abstract contract ERC721Handler is IERC721Handler, ERC721Holder {
+    /**
+     * @inheritdoc IERC721Handler
+     */
     function depositERC721(
         address token_,
         uint256 tokenId_,
         string calldata receiver_,
         string calldata network_,
-        bool isWrapped_
+        ERC721BridgingType operationType_
     ) external override {
         require(token_ != address(0), "ERC721Handler: zero token");
 
         IERC721MintableBurnable erc721_ = IERC721MintableBurnable(token_);
 
-        if (isWrapped_) {
+        if (operationType_ == ERC721BridgingType.Wrapped) {
             erc721_.burnFrom(msg.sender, tokenId_);
         } else {
             erc721_.safeTransferFrom(msg.sender, address(this), tokenId_);
         }
 
-        emit DepositedERC721(token_, tokenId_, receiver_, network_, isWrapped_);
+        emit DepositedERC721(token_, tokenId_, receiver_, network_, operationType_);
     }
 
     function _withdrawERC721(
@@ -32,20 +38,23 @@ abstract contract ERC721Handler is IERC721Handler, ERC721Holder {
         uint256 tokenId_,
         address receiver_,
         string calldata tokenURI_,
-        bool isWrapped_
+        ERC721BridgingType operationType_
     ) internal {
         require(token_ != address(0), "ERC721Handler: zero token");
         require(receiver_ != address(0), "ERC721Handler: zero receiver");
 
         IERC721MintableBurnable erc721_ = IERC721MintableBurnable(token_);
 
-        if (isWrapped_) {
+        if (operationType_ == ERC721BridgingType.Wrapped) {
             erc721_.mintTo(receiver_, tokenId_, tokenURI_);
         } else {
             erc721_.safeTransferFrom(address(this), receiver_, tokenId_);
         }
     }
 
+    /**
+     * @inheritdoc IERC721Handler
+     */
     function getERC721SignHash(
         address token_,
         uint256 tokenId_,
@@ -54,7 +63,7 @@ abstract contract ERC721Handler is IERC721Handler, ERC721Holder {
         uint256 txNonce_,
         uint256 chainId_,
         string calldata tokenURI_,
-        bool isWrapped_
+        ERC721BridgingType operationType_
     ) public pure returns (bytes32) {
         return
             keccak256(
@@ -66,7 +75,7 @@ abstract contract ERC721Handler is IERC721Handler, ERC721Holder {
                     txNonce_,
                     chainId_,
                     tokenURI_,
-                    isWrapped_
+                    operationType_
                 )
             );
     }

--- a/contracts/handlers/NativeHandler.sol
+++ b/contracts/handlers/NativeHandler.sol
@@ -1,9 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "../interfaces/handlers/INativeHandler.sol";
+import {INativeHandler} from "../interfaces/handlers/INativeHandler.sol";
 
+/**
+ * @title NativeHandler
+ */
 abstract contract NativeHandler is INativeHandler {
+    receive() external payable {}
+
+    /**
+     * @inheritdoc INativeHandler
+     */
     function depositNative(
         string calldata receiver_,
         string calldata network_
@@ -12,8 +20,6 @@ abstract contract NativeHandler is INativeHandler {
 
         emit DepositedNative(msg.value, receiver_, network_);
     }
-
-    receive() external payable {}
 
     function _withdrawNative(uint256 amount_, address receiver_) internal {
         require(amount_ > 0, "NativeHandler: amount is zero");
@@ -24,6 +30,9 @@ abstract contract NativeHandler is INativeHandler {
         require(sent_, "NativeHandler: can't send eth");
     }
 
+    /**
+     * @inheritdoc INativeHandler
+     */
     function getNativeSignHash(
         uint256 amount_,
         address receiver_,

--- a/contracts/interfaces/bridge/IBridge.sol
+++ b/contracts/interfaces/bridge/IBridge.sol
@@ -1,37 +1,35 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "../handlers/IERC20Handler.sol";
-import "../handlers/IERC721Handler.sol";
-import "../handlers/IERC1155Handler.sol";
-import "../handlers/INativeHandler.sol";
+import {IERC20Handler} from "../handlers/IERC20Handler.sol";
+import {IERC721Handler} from "../handlers/IERC721Handler.sol";
+import {IERC1155Handler} from "../handlers/IERC1155Handler.sol";
+import {INativeHandler} from "../handlers/INativeHandler.sol";
 
 /**
- * @notice The Bridge contract
+ * @title The Bridge Contract
  *
- * The Bridge contract acts as a permissioned way of transfering assets (ERC20, ERC721, ERC1155, Native) between
- * 2 different blockchains.
+ * The Bridge contract facilitates the permissioned transfer of assets (ERC20, ERC721, ERC1155, Native) between two different blockchains.
  *
- * In order to correctly use the Bridge, one has to deploy both instances of the contract on the base chain and the
- * destination chain, as well as setup a trusted backend that will act as a `signer`.
+ * To utilize the Bridge effectively, instances of the contract must be deployed on both the base and destination chains,
+ * accompanied by the setup of a trusted backend to act as a `signer`.
  *
- * Each Bridge contract can either give or take the user assets when they want to transfer tokens. Both liquidity pool
- * and mint-and-burn way of transferring assets are supported.
+ * The Bridge contract supports both the liquidity pool method and the mint-and-burn method for transferring assets.
+ * Users can either deposit or withdraw assets through the contract during a transfer operation.
  *
- * IMPORTANT
- *
- * All of the signers' addresses must differ in they first (the most significant) 8 bits in order to pass a bloom filtering.
+ * IMPORTANT:
+ * All signer addresses must differ in their first (most significant) 8 bits in order to pass a bloom filtering.
  */
 interface IBridge is IERC20Handler, IERC721Handler, IERC1155Handler, INativeHandler {
     /**
-     * @notice function for withdrawing erc20 tokens
-     * @param token_ the address of withdrawn token
-     * @param amount_ the amount of withdrawn tokens
-     * @param receiver_ the address of withdraw receiver
-     * @param txHash_ the hash of deposit tranaction
-     * @param txNonce_ the nonce of deposit transaction
-     * @param isWrapped_ the boolean flag, if true - tokens will minted, false - tokens will transferred
-     * @param signatures_ the array of signatures. Formed by signing a sign hash by each signer.
+     * @notice Withdraws ERC20 tokens.
+     * @param token_ The address of the token to withdraw.
+     * @param amount_ The amount of tokens to withdraw.
+     * @param receiver_ The address of the withdrawal recipient.
+     * @param txHash_ The hash of the deposit transaction.
+     * @param txNonce_ The nonce of the deposit transaction.
+     * @param operationType_ The type of bridging operation.
+     * @param signatures_ An array of signatures, formed by signing a sign hash by each signer.
      */
     function withdrawERC20(
         address token_,
@@ -39,20 +37,20 @@ interface IBridge is IERC20Handler, IERC721Handler, IERC1155Handler, INativeHand
         address receiver_,
         bytes32 txHash_,
         uint256 txNonce_,
-        bool isWrapped_,
+        ERC20BridgingType operationType_,
         bytes[] calldata signatures_
     ) external;
 
     /**
-     * @notice function for withdrawing erc721 tokens
-     * @param token_ the address of withdrawn token
-     * @param tokenId_ the id of withdrawn token
-     * @param receiver_ the address of withdraw receiver
-     * @param txHash_ the hash of deposit tranaction
-     * @param txNonce_ the nonce of deposit transaction
-     * @param tokenURI_ the string URI to token metadata
-     * @param isWrapped_ the boolean flag, if true - tokens will minted, false - tokens will transferred
-     * @param signatures_ the array of signatures. Formed by signing a sign hash by each signer.
+     * @notice Withdraws ERC721 tokens.
+     * @param token_ The address of the token to withdraw.
+     * @param tokenId_ The ID of the token to withdraw.
+     * @param receiver_ The address of the withdrawal recipient.
+     * @param txHash_ The hash of the deposit transaction.
+     * @param txNonce_ The nonce of the deposit transaction.
+     * @param tokenURI_ The string URI of the token metadata.
+     * @param operationType_ The type of bridging operation.
+     * @param signatures_ An array of signatures, formed by signing a sign hash by each signer.
      */
     function withdrawERC721(
         address token_,
@@ -61,21 +59,21 @@ interface IBridge is IERC20Handler, IERC721Handler, IERC1155Handler, INativeHand
         bytes32 txHash_,
         uint256 txNonce_,
         string calldata tokenURI_,
-        bool isWrapped_,
+        ERC721BridgingType operationType_,
         bytes[] calldata signatures_
     ) external;
 
     /**
-     * @notice function for withdrawing erc1155 tokens
-     * @param token_ the address of withdrawn token
-     * @param tokenId_ the id of withdrawn token
-     * @param amount_ the amount of withdrawn tokens
-     * @param receiver_ the address of withdraw receiver
-     * @param txHash_ the hash of deposit tranaction
-     * @param txNonce_ the nonce of deposit transaction
-     * @param tokenURI_ the string URI to token metadata
-     * @param isWrapped_ the boolean flag, if true - tokens will minted, false - tokens will transferred
-     * @param signatures_ the array of signatures. Formed by signing a sign hash by each signer.
+     * @notice Withdraws ERC1155 tokens.
+     * @param token_ The address of the token to withdraw.
+     * @param tokenId_ The ID of the token to withdraw.
+     * @param amount_ The amount of tokens to withdraw.
+     * @param receiver_ The address of the withdrawal recipient.
+     * @param txHash_ The hash of the deposit transaction.
+     * @param txNonce_ The nonce of the deposit transaction.
+     * @param tokenURI_ The string URI of the token metadata.
+     * @param operationType_ The type of bridging operation.
+     * @param signatures_ An array of signatures, formed by signing a sign hash by each signer.
      */
     function withdrawERC1155(
         address token_,
@@ -85,17 +83,17 @@ interface IBridge is IERC20Handler, IERC721Handler, IERC1155Handler, INativeHand
         bytes32 txHash_,
         uint256 txNonce_,
         string calldata tokenURI_,
-        bool isWrapped_,
+        ERC1155BridgingType operationType_,
         bytes[] calldata signatures_
     ) external;
 
     /**
-     * @notice function for withdrawing native currency
-     * @param amount_ the amount of withdrawn native currency
-     * @param receiver_ the address of withdraw receiver
-     * @param txHash_ the hash of deposit tranaction
-     * @param txNonce_ the nonce of deposit transaction
-     * @param signatures_ the array of signatures. Formed by signing a sign hash by each signer.
+     * @notice Withdraws native currency.
+     * @param amount_ The amount of native currency to withdraw.
+     * @param receiver_ The address of the withdrawal recipient.
+     * @param txHash_ The hash of the deposit transaction.
+     * @param txNonce_ The nonce of the deposit transaction.
+     * @param signatures_ An array of signatures, formed by signing a sign hash by each signer.
      */
     function withdrawNative(
         uint256 amount_,

--- a/contracts/interfaces/handlers/IERC1155Handler.sol
+++ b/contracts/interfaces/handlers/IERC1155Handler.sol
@@ -1,9 +1,26 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
+/**
+ * @title IERC1155Handler
+ */
 interface IERC1155Handler {
     /**
-     * @notice event emits from depositERC1155 function
+     * @notice Enumerates the types of ERC1155 token bridging options.
+     */
+    enum ERC1155BridgingType {
+        LiquidityPool,
+        Wrapped
+    }
+
+    /**
+     * @dev Emitted when ERC1155 tokens are deposited for bridging.
+     * @param token The address of the ERC1155 token being bridged.
+     * @param tokenId The ID of the token deposited for bridging.
+     * @param amount The amount of tokens deposited for bridging.
+     * @param receiver The receiver's address in the destination network.
+     * @param network The name of the destination network.
+     * @param operationType The type of bridging operation performed.
      */
     event DepositedERC1155(
         address token,
@@ -11,17 +28,17 @@ interface IERC1155Handler {
         uint256 amount,
         string receiver,
         string network,
-        bool isWrapped
+        ERC1155BridgingType operationType
     );
 
     /**
-     * @notice function for depositing erc1155 tokens, emits event DepositedERC115
-     * @param token_ the address of deposited tokens
-     * @param tokenId_ the id of deposited tokens
-     * @param amount_ the amount of deposited tokens
-     * @param receiver_ the receiver address in destination network, information field for event
-     * @param network_ the network name of destination network, information field for event
-     * @param isWrapped_ the boolean flag, if true - tokens will burned, false - tokens will transferred
+     * @notice Deposits ERC1155 tokens for bridging, emitting a `DepositedERC1155` event.
+     * @param token_ The address of the deposited tokens.
+     * @param tokenId_ The ID of the deposited tokens.
+     * @param amount_ The amount of deposited tokens.
+     * @param receiver_ The receiver's address in the destination network, used as an informational field for the event.
+     * @param network_ The name of the destination network, used as an informational field for the event.
+     * @param operationType_ The type of bridging operation being performed.
      */
     function depositERC1155(
         address token_,
@@ -29,21 +46,22 @@ interface IERC1155Handler {
         uint256 amount_,
         string calldata receiver_,
         string calldata network_,
-        bool isWrapped_
+        ERC1155BridgingType operationType_
     ) external;
 
     /**
-     * @notice function for getting sign hash
-     * @param token_ the address of withdrawn token
-     * @param tokenId_ the id of deposited token
-     * @param amount_ the amount of withdrawn tokens
-     * @param receiver_ the receiver address in destination network
-     * @param txHash_ the hash of deposit tranaction
-     * @param txNonce_ the nonce of deposit transaction
-     * @param chainId_ the id of chain
-     * @param tokenURI_ the string URI to token metadata
-     * @param isWrapped_ the boolean flag, if true - tokens will minted, false - tokens will transferred
-     * @return bytes32 keccak256(abi.encodePacked(token_,tokenId_,amount_,receiver_,txHash_,txNonce_,chainId_,isWrapped_));
+     * @notice Generates a hash for signing, related to a specific ERC1155 bridging operation.
+     * @param token_ The address of the token being withdrawn.
+     * @param tokenId_ The ID of the deposited token.
+     * @param amount_ The amount of tokens being withdrawn.
+     * @param receiver_ The receiver's address in the destination network.
+     * @param txHash_ The hash of the deposit transaction.
+     * @param txNonce_ The nonce of the deposit transaction.
+     * @param chainId_ The ID of the chain where the operation is being performed.
+     * @param tokenURI_ The string URI to the token metadata.
+     * @param operationType_ The type of bridging operation.
+     * @return A `bytes32` hash, computed using `keccak256` of the encoded parameters:
+     *         keccak256(abi.encodePacked(token_,tokenId_,amount_,receiver_,txHash_,txNonce_,chainId_,tokenURI_,operationType_));
      */
     function getERC1155SignHash(
         address token_,
@@ -54,6 +72,6 @@ interface IERC1155Handler {
         uint256 txNonce_,
         uint256 chainId_,
         string calldata tokenURI_,
-        bool isWrapped_
+        ERC1155BridgingType operationType_
     ) external pure returns (bytes32);
 }

--- a/contracts/interfaces/handlers/IERC20Handler.sol
+++ b/contracts/interfaces/handlers/IERC20Handler.sol
@@ -1,44 +1,62 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
+/**
+ * @title IERC20Handler
+ */
 interface IERC20Handler {
     /**
-     * @notice event emits from depositERC20 function
+     * @dev Enumerates the types of ERC20 token bridging options.
+     */
+    enum ERC20BridgingType {
+        LiquidityPool,
+        Wrapped,
+        USDCType
+    }
+
+    /**
+     * @dev Emitted when ERC20 tokens are deposited for bridging.
+     * @param token The address of the ERC20 token being bridged.
+     * @param amount The amount of tokens deposited for bridging.
+     * @param receiver The receiver's address in the destination network.
+     * @param network The name of the destination network.
+     * @param operationType The type of bridging operation performed.
      */
     event DepositedERC20(
         address token,
         uint256 amount,
         string receiver,
         string network,
-        bool isWrapped
+        ERC20BridgingType operationType
     );
 
     /**
-     * @notice function for depositing erc20 tokens, emits event DepositedERC20
-     * @param token_ the address of deposited token
-     * @param amount_ the amount of deposited tokens
-     * @param receiver_ the receiver address in destination network, information field for event
-     * @param network_ the network name of destination network, information field for event
-     * @param isWrapped_ the boolean flag, if true - tokens will burned, false - tokens will transferred
+     * @notice Deposits ERC20 tokens for bridging, emitting a `DepositedERC20` event.
+     * @param token_ The address of the deposited token.
+     * @param amount_ The amount of deposited tokens.
+     * @param receiver_ The receiver's address in the destination network, used as an informational field for the event.
+     * @param network_ The name of the destination network, used as an informational field for the event.
+     * @param operationType_ The type of bridging operation being performed.
      */
     function depositERC20(
         address token_,
         uint256 amount_,
         string calldata receiver_,
         string calldata network_,
-        bool isWrapped_
+        ERC20BridgingType operationType_
     ) external;
 
     /**
-     * @notice function for getting sign hash
-     * @param token_ the address of withdrawn token
-     * @param amount_ the amount of withdrawn tokens
-     * @param receiver_ the receiver address in destination network
-     * @param txHash_ the hash of deposit tranaction
-     * @param txNonce_ the nonce of deposit transaction
-     * @param chainId_ the id of chain
-     * @param isWrapped_ the boolean flag, if true - tokens will minted, false - tokens will transferred
-     * @return bytes32 keccak256(abi.encodePacked(token_,amount_,receiver_,txHash_,txNonce_,chainId_,isWrapped_));
+     * @notice Generates a hash for signing, related to a specific ERC20 bridging operation.
+     * @param token_ The address of the token being withdrawn.
+     * @param amount_ The amount of tokens being withdrawn.
+     * @param receiver_ The receiver's address in the destination network.
+     * @param txHash_ The hash of the deposit transaction.
+     * @param txNonce_ The nonce of the deposit transaction.
+     * @param chainId_ The ID of the chain where the operation is being performed.
+     * @param operationType_ The type of bridging operation.
+     * @return A `bytes32` hash, computed using keccak256 of the encoded parameters:
+     *         keccak256(abi.encodePacked(token_,amount_,receiver_,txHash_,txNonce_,chainId_,operationType_));
      */
     function getERC20SignHash(
         address token_,
@@ -47,6 +65,6 @@ interface IERC20Handler {
         bytes32 txHash_,
         uint256 txNonce_,
         uint256 chainId_,
-        bool isWrapped_
+        ERC20BridgingType operationType_
     ) external pure returns (bytes32);
 }

--- a/contracts/interfaces/handlers/IERC721Handler.sol
+++ b/contracts/interfaces/handlers/IERC721Handler.sol
@@ -1,45 +1,62 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
+/**
+ * @title IERC721Handler
+ */
 interface IERC721Handler {
     /**
-     * @notice event emits from depositERC721 function
+     * @notice Enumerates the types of ERC721 token bridging options.
+     */
+    enum ERC721BridgingType {
+        LiquidityPool,
+        Wrapped
+    }
+
+    /**
+     * @dev Emitted when ERC721 tokens are deposited for bridging.
+     * @param token The address of the ERC721 token being bridged.
+     * @param tokenId The ID of the token deposited for bridging.
+     * @param receiver The receiver's address in the destination network.
+     * @param network The name of the destination network.
+     * @param operationType The type of bridging operation performed.
      */
     event DepositedERC721(
         address token,
         uint256 tokenId,
         string receiver,
         string network,
-        bool isWrapped
+        ERC721BridgingType operationType
     );
 
     /**
-     * @notice function for depositing erc721 tokens, emits event DepositedERC721
-     * @param token_ the address of deposited token
-     * @param tokenId_ the id of deposited token
-     * @param receiver_ the receiver address in destination network, information field for event
-     * @param network_ the network name of destination network, information field for event
-     * @param isWrapped_ the boolean flag, if true - token will burned, false - token will transferred
+     * @notice Deposits ERC721 tokens for bridging, emitting a `DepositedERC721` event.
+     * @param token_ The address of the deposited token.
+     * @param tokenId_ The ID of the deposited token.
+     * @param receiver_ The receiver's address in the destination network, used as an informational field for the event.
+     * @param network_ The name of the destination network, used as an informational field for the event.
+     * @param operationType_ The type of bridging operation being performed.
      */
     function depositERC721(
         address token_,
         uint256 tokenId_,
         string calldata receiver_,
         string calldata network_,
-        bool isWrapped_
+        ERC721BridgingType operationType_
     ) external;
 
     /**
-     * @notice function for getting sign hash
-     * @param token_ the address of withdrawn token
-     * @param tokenId_ the id of deposited token
-     * @param receiver_ the receiver address in destination network
-     * @param txHash_ the hash of deposit tranaction
-     * @param txNonce_ the nonce of deposit transaction
-     * @param chainId_ the id of chain
-     * @param tokenURI_ the string URI to token metadata
-     * @param isWrapped_ the boolean flag, if true - tokens will minted, false - tokens will transferred
-     * @return bytes32 keccak256(abi.encodePacked(token_,tokenId_,receiver_,txHash_,txNonce_,chainId_,isWrapped_));
+     * @notice Generates a hash for signing, related to a specific ERC721 bridging operation.
+     * @param token_ The address of the token being withdrawn.
+     * @param tokenId_ The ID of the deposited token.
+     * @param receiver_ The receiver's address in the destination network.
+     * @param txHash_ The hash of the deposit transaction.
+     * @param txNonce_ The nonce of the deposit transaction.
+     * @param chainId_ The ID of the chain where the operation is being performed.
+     * @param tokenURI_ The string URI to the token metadata.
+     * @param operationType_ The type of bridging operation.
+     * @return A `bytes32` hash, computed using `keccak256` of the encoded parameters:
+     *         keccak256(abi.encodePacked(token_,tokenId_,receiver_,txHash_,txNonce_,chainId_,tokenURI_,operationType_));
      */
     function getERC721SignHash(
         address token_,
@@ -49,6 +66,6 @@ interface IERC721Handler {
         uint256 txNonce_,
         uint256 chainId_,
         string calldata tokenURI_,
-        bool isWrapped_
+        ERC721BridgingType operationType_
     ) external pure returns (bytes32);
 }

--- a/contracts/interfaces/handlers/INativeHandler.sol
+++ b/contracts/interfaces/handlers/INativeHandler.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
+/**
+ * @title INativeHandler
+ */
 interface INativeHandler {
     /**
      * @notice event emits from depositNative function

--- a/contracts/interfaces/tokens/IERC1155MintableBurnable.sol
+++ b/contracts/interfaces/tokens/IERC1155MintableBurnable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 
 interface IERC1155MintableBurnable is IERC1155 {
     function mintTo(

--- a/contracts/interfaces/tokens/IERC20MintableBurnable.sol
+++ b/contracts/interfaces/tokens/IERC20MintableBurnable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IERC20MintableBurnable is IERC20 {
     function mintTo(address receiver_, uint256 amount_) external;

--- a/contracts/interfaces/tokens/IERC721MintableBurnable.sol
+++ b/contracts/interfaces/tokens/IERC721MintableBurnable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 interface IERC721MintableBurnable is IERC721 {
     function mintTo(address receiver_, uint256 tokenId_, string calldata tokenURI_) external;

--- a/contracts/interfaces/tokens/IUSDCType.sol
+++ b/contracts/interfaces/tokens/IUSDCType.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IUSDCType is IERC20 {
+    function mint(address receiver_, uint256 amount_) external;
+
+    function burn(uint256 amount_) external;
+}

--- a/contracts/mocks/handlers/ERC1155HandlerMock.sol
+++ b/contracts/mocks/handlers/ERC1155HandlerMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "../../handlers/ERC1155Handler.sol";
+import {ERC1155Handler} from "../../handlers/ERC1155Handler.sol";
 
 contract ERC1155HandlerMock is ERC1155Handler {
     function withdrawERC1155(
@@ -10,8 +10,8 @@ contract ERC1155HandlerMock is ERC1155Handler {
         uint256 amount_,
         address receiver_,
         string calldata tokenURI_,
-        bool isWrapped_
+        ERC1155BridgingType operationType_
     ) external {
-        _withdrawERC1155(token_, tokenId_, amount_, receiver_, tokenURI_, isWrapped_);
+        _withdrawERC1155(token_, tokenId_, amount_, receiver_, tokenURI_, operationType_);
     }
 }

--- a/contracts/mocks/handlers/ERC20HanlderMock.sol
+++ b/contracts/mocks/handlers/ERC20HanlderMock.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "../../handlers/ERC20Handler.sol";
+import {ERC20Handler} from "../../handlers/ERC20Handler.sol";
 
 contract ERC20HandlerMock is ERC20Handler {
     function withdrawERC20(
         address token_,
         uint256 amount_,
         address receiver_,
-        bool isWrapped_
+        ERC20BridgingType operationType_
     ) external {
-        _withdrawERC20(token_, amount_, receiver_, isWrapped_);
+        _withdrawERC20(token_, amount_, receiver_, operationType_);
     }
 }

--- a/contracts/mocks/handlers/ERC721HandlerMock.sol
+++ b/contracts/mocks/handlers/ERC721HandlerMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "../../handlers/ERC721Handler.sol";
+import {ERC721Handler} from "../../handlers/ERC721Handler.sol";
 
 contract ERC721HandlerMock is ERC721Handler {
     function withdrawERC721(
@@ -9,8 +9,8 @@ contract ERC721HandlerMock is ERC721Handler {
         uint256 tokenId_,
         address receiver_,
         string calldata tokenURI_,
-        bool isWrapped_
+        ERC721BridgingType operationType_
     ) external {
-        _withdrawERC721(token_, tokenId_, receiver_, tokenURI_, isWrapped_);
+        _withdrawERC721(token_, tokenId_, receiver_, tokenURI_, operationType_);
     }
 }

--- a/contracts/mocks/handlers/NativeHandlerMock.sol
+++ b/contracts/mocks/handlers/NativeHandlerMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "../../handlers/NativeHandler.sol";
+import {NativeHandler} from "../../handlers/NativeHandler.sol";
 
 contract NativeHandlerMock is NativeHandler {
     function withdrawNative(uint256 amount_, address receiver_) external {

--- a/contracts/mocks/helpers/ERC1967ProxyMock.sol
+++ b/contracts/mocks/helpers/ERC1967ProxyMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract ERC1967ProxyMock is ERC1967Proxy {
     constructor(address _logic, bytes memory _data) ERC1967Proxy(_logic, _data) {}

--- a/contracts/mocks/tokens/USDCTypeToken.sol
+++ b/contracts/mocks/tokens/USDCTypeToken.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IUSDCType} from "../../interfaces/tokens/IUSDCType.sol";
+
+contract USDCTokenType is IERC20, IUSDCType, ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address receiver_, uint256 amount_) external {
+        _mint(receiver_, amount_);
+    }
+
+    function burn(uint256 amount_) external override {
+        _burn(msg.sender, amount_);
+    }
+}

--- a/contracts/mocks/utils/HashesMock.sol
+++ b/contracts/mocks/utils/HashesMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "../../utils/Hashes.sol";
+import {Hashes} from "../../utils/Hashes.sol";
 
 contract HashesMock is Hashes {
     function checkAndUpdateHashes(bytes32 txHash_, uint256 txNonce_) external {

--- a/contracts/mocks/utils/SignersMock.sol
+++ b/contracts/mocks/utils/SignersMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "../../utils/Signers.sol";
+import {Signers} from "../../utils/Signers.sol";
 
 contract SignersMock is Signers {
     function __SignersMock_init(

--- a/contracts/tokens/ERC1155MintableBurnable.sol
+++ b/contracts/tokens/ERC1155MintableBurnable.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
-import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155URIStorage.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {ERC1155Supply} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
+import {ERC1155URIStorage} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155URIStorage.sol";
 
-import "../interfaces/tokens/IERC1155MintableBurnable.sol";
+import {IERC1155MintableBurnable} from "../interfaces/tokens/IERC1155MintableBurnable.sol";
 
 contract ERC1155MintableBurnable is
     IERC1155MintableBurnable,

--- a/contracts/tokens/ERC20MintableBurnable.sol
+++ b/contracts/tokens/ERC20MintableBurnable.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-import "../interfaces/tokens/IERC20MintableBurnable.sol";
+import {IERC20MintableBurnable} from "../interfaces/tokens/IERC20MintableBurnable.sol";
 
 contract ERC20MintableBurnable is IERC20MintableBurnable, Ownable, ERC20 {
     constructor(string memory name_, string memory symbol_, address owner_) ERC20(name_, symbol_) {

--- a/contracts/tokens/ERC721MintableBurnable.sol
+++ b/contracts/tokens/ERC721MintableBurnable.sol
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import {ERC721URIStorage} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 
-import "../interfaces/tokens/IERC721MintableBurnable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+import {IERC721MintableBurnable} from "../interfaces/tokens/IERC721MintableBurnable.sol";
 
 contract ERC721MintableBurnable is
     IERC721MintableBurnable,

--- a/contracts/utils/Hashes.sol
+++ b/contracts/utils/Hashes.sol
@@ -4,16 +4,17 @@ pragma solidity ^0.8.9;
 abstract contract Hashes {
     mapping(bytes32 => bool) public usedHashes; // keccak256(txHash . txNonce) => is used
 
+    function containsHash(bytes32 txHash_, uint256 txNonce_) external view returns (bool) {
+        bytes32 nonceHash_ = keccak256(abi.encodePacked(txHash_, txNonce_));
+
+        return usedHashes[nonceHash_];
+    }
+
     function _checkAndUpdateHashes(bytes32 txHash_, uint256 txNonce_) internal {
         bytes32 nonceHash_ = keccak256(abi.encodePacked(txHash_, txNonce_));
 
         require(!usedHashes[nonceHash_], "Hashes: the hash nonce is used");
 
         usedHashes[nonceHash_] = true;
-    }
-
-    function containsHash(bytes32 txHash_, uint256 txNonce_) external view returns (bool) {
-        bytes32 nonceHash_ = keccak256(abi.encodePacked(txHash_, txNonce_));
-        return usedHashes[nonceHash_];
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,6 +3,7 @@ import "@nomicfoundation/hardhat-chai-matchers";
 
 import "@typechain/hardhat";
 
+import "@solarity/hardhat-gobind";
 import "@solarity/hardhat-migrate";
 
 import "hardhat-contract-sizer";

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^2.0.4",
         "@nomicfoundation/hardhat-ethers": "^3.0.5",
+        "@solarity/hardhat-gobind": "v1.1.1",
         "@solarity/hardhat-habits": "^1.0.0",
         "@solarity/hardhat-migrate": "^2.0.1",
         "@typechain/ethers-v6": "^0.5.1",
@@ -38,6 +39,32 @@
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typechain": "^8.3.2"
+      }
+    },
+    "../../Solarity/hardhat-gobind": {
+      "name": "@solarity/hardhat-gobind",
+      "version": "1.1.1",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "4.17.21"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.3.4",
+        "@types/mocha": "^10.0.1",
+        "chai": "^4.3.7",
+        "hardhat": "^2.10.0",
+        "husky": "^7.0.2",
+        "mocha": "^10.2.0",
+        "pinst": "^3.0.0",
+        "prettier": "^2.7.1",
+        "prettier-plugin-solidity": "^1.1.1",
+        "ts-node": "^8.1.0",
+        "typescript": "~4.5.2"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.10.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -2193,6 +2220,10 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@solarity/hardhat-gobind": {
+      "resolved": "../../Solarity/hardhat-gobind",
+      "link": true
     },
     "node_modules/@solarity/hardhat-habits": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "deploy-eth-mainnet": "npx hardhat migrate --network eth_mainnet",
     "deploy-bsc-mainnet": "npx hardhat migrate --network bsc_mainnet",
     "generate-types": "TYPECHAIN_FORCE=true npx hardhat typechain",
+    "generate-go-bindings": "npx hardhat gobind --outdir ./go-bindings",
     "lint-fix": "npm run lint-sol-fix && npm run lint-ts-fix && npm run lint-json-fix",
     "lint-json-fix": "prettier --write \"./[a-zA-Z0-9.]+(?!-lock).json\"",
     "lint-ts-fix": "prettier --write \"./**/*.ts\"",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.4",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
+    "@solarity/hardhat-gobind": "v1.1.1",
     "@solarity/hardhat-habits": "^1.0.0",
     "@solarity/hardhat-migrate": "^2.0.1",
     "@typechain/ethers-v6": "^0.5.1",

--- a/test/handlers/ERC20Handler.test.ts
+++ b/test/handlers/ERC20Handler.test.ts
@@ -5,9 +5,9 @@ import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 import { wei } from "@scripts";
 
-import { Reverter } from "@test-helpers";
+import { Reverter, ERC20BridgingType } from "@test-helpers";
 
-import { ERC20HandlerMock, ERC20MintableBurnable } from "@ethers-v6";
+import { ERC20HandlerMock, ERC20MintableBurnable, USDCTokenType } from "@ethers-v6";
 
 describe("ERC20Handler", () => {
   const reverter = new Reverter();
@@ -17,6 +17,7 @@ describe("ERC20Handler", () => {
   let OWNER: SignerWithAddress;
 
   let token: ERC20MintableBurnable;
+  let usdcTokenType: USDCTokenType;
   let handler: ERC20HandlerMock;
 
   before("setup", async () => {
@@ -24,6 +25,9 @@ describe("ERC20Handler", () => {
 
     const ERC20MB = await ethers.getContractFactory("ERC20MintableBurnable");
     token = await ERC20MB.deploy("Mock", "MK", OWNER.address);
+
+    const USDCTokenType = await ethers.getContractFactory("USDCTokenType");
+    usdcTokenType = await USDCTokenType.deploy("USDCMock", "USDCMock");
 
     const ERC20HandlerMock = await ethers.getContractFactory("ERC20HandlerMock");
     handler = await ERC20HandlerMock.deploy();
@@ -33,16 +37,25 @@ describe("ERC20Handler", () => {
 
     await token.transferOwnership(await handler.getAddress());
 
+    await usdcTokenType.mint(OWNER.address, baseBalance);
+    await usdcTokenType.approve(await handler.getAddress(), baseBalance);
+
     await reverter.snapshot();
   });
 
   afterEach(reverter.revert);
 
   describe("depositERC20", () => {
-    it("should deposit 100 tokens, isWrapped = true", async () => {
+    it("should deposit 100 tokens, operationType = Wrapped", async () => {
       const expectedAmount = wei("100");
 
-      await handler.depositERC20(await token.getAddress(), expectedAmount, "receiver", "kovan", true);
+      await handler.depositERC20(
+        await token.getAddress(),
+        expectedAmount,
+        "receiver",
+        "kovan",
+        ERC20BridgingType.Wrapped,
+      );
 
       expect(await token.balanceOf(OWNER.address)).to.equal(baseBalance - expectedAmount);
       expect(await token.balanceOf(await handler.getAddress())).to.equal(0);
@@ -54,7 +67,7 @@ describe("ERC20Handler", () => {
       expect(depositEvent.args.amount).to.be.equal(expectedAmount);
       expect(depositEvent.args.receiver).to.be.equal("receiver");
       expect(depositEvent.args.network).to.be.equal("kovan");
-      expect(depositEvent.args.isWrapped).to.be.true;
+      expect(depositEvent.args.operationType).to.be.equal(ERC20BridgingType.Wrapped);
     });
 
     it("should not burn tokens if they are not approved", async () => {
@@ -63,32 +76,56 @@ describe("ERC20Handler", () => {
       await token.approve(await handler.getAddress(), 0);
 
       await expect(
-        handler.depositERC20(await token.getAddress(), expectedAmount, "receiver", "kovan", true),
+        handler.depositERC20(await token.getAddress(), expectedAmount, "receiver", "kovan", ERC20BridgingType.Wrapped),
       ).to.be.rejectedWith("ERC20: insufficient allowance");
     });
 
-    it("should deposit 52 tokens, isWrapped = false", async () => {
+    it("should deposit 52 tokens, operationType = LiquidityPool", async () => {
       let expectedAmount = wei("52");
 
-      await handler.depositERC20(await token.getAddress(), expectedAmount, "receiver", "kovan", false);
+      await handler.depositERC20(
+        await token.getAddress(),
+        expectedAmount,
+        "receiver",
+        "kovan",
+        ERC20BridgingType.LiquidityPool,
+      );
 
       expect(await token.balanceOf(OWNER.address)).to.equal(baseBalance - expectedAmount);
       expect(await token.balanceOf(await handler.getAddress())).to.equal(expectedAmount);
 
       const depositEvent = (await handler.queryFilter(handler.filters.DepositedERC20, -1))[0];
-      expect(depositEvent.args.isWrapped).to.be.false;
+      expect(depositEvent.args.operationType).to.be.equal(ERC20BridgingType.LiquidityPool);
+    });
+
+    it("should deposit 50 tokens, operationType = USDCType", async () => {
+      let expectedAmount = wei("50");
+
+      await handler.depositERC20(
+        await usdcTokenType.getAddress(),
+        expectedAmount,
+        "receiver",
+        "kovan",
+        ERC20BridgingType.USDCType,
+      );
+
+      expect(await usdcTokenType.balanceOf(OWNER.address)).to.equal(baseBalance - expectedAmount);
+      expect(await usdcTokenType.balanceOf(await handler.getAddress())).to.equal(0);
+
+      const depositEvent = (await handler.queryFilter(handler.filters.DepositedERC20, -1))[0];
+      expect(depositEvent.args.operationType).to.be.equal(ERC20BridgingType.USDCType);
     });
 
     it("should revert when try deposit 0 tokens", async () => {
       await expect(
-        handler.depositERC20(await token.getAddress(), wei("0"), "receiver", "kovan", false),
+        handler.depositERC20(await token.getAddress(), wei("0"), "receiver", "kovan", ERC20BridgingType.LiquidityPool),
       ).to.be.rejectedWith("ERC20Handler: amount is zero");
     });
 
     it("should revert when token address is 0", async () => {
-      await expect(handler.depositERC20(ethers.ZeroAddress, wei("1"), "receiver", "kovan", false)).to.be.rejectedWith(
-        "ERC20Handler: zero token",
-      );
+      await expect(
+        handler.depositERC20(ethers.ZeroAddress, wei("1"), "receiver", "kovan", ERC20BridgingType.LiquidityPool),
+      ).to.be.rejectedWith("ERC20Handler: zero token");
     });
   });
 
@@ -98,7 +135,7 @@ describe("ERC20Handler", () => {
       let expectedTxHash = "0xc4f46c912cc2a1f30891552ac72871ab0f0e977886852bdd5dccd221a595647d";
       let expectedNonce = "1794147";
       let expectedChainId = 31378;
-      let expectedIsWrapped = true;
+      let expectedOperationType = ERC20BridgingType.Wrapped;
 
       let signHash0 = await handler.getERC20SignHash(
         await token.getAddress(),
@@ -107,13 +144,13 @@ describe("ERC20Handler", () => {
         expectedTxHash,
         expectedNonce,
         expectedChainId,
-        expectedIsWrapped,
+        expectedOperationType,
       );
 
       expect(signHash0).to.be.equal(
         ethers.keccak256(
           ethers.solidityPacked(
-            ["address", "uint256", "address", "bytes32", "uint256", "uint256", "bool"],
+            ["address", "uint256", "address", "bytes32", "uint256", "uint256", "uint8"],
             [
               await token.getAddress(),
               expectedAmount,
@@ -121,13 +158,13 @@ describe("ERC20Handler", () => {
               expectedTxHash,
               expectedNonce,
               expectedChainId,
-              expectedIsWrapped,
+              expectedOperationType,
             ],
           ),
         ),
       );
 
-      expectedIsWrapped = false;
+      expectedOperationType = ERC20BridgingType.LiquidityPool;
 
       let signHash1 = await handler.getERC20SignHash(
         await token.getAddress(),
@@ -136,13 +173,13 @@ describe("ERC20Handler", () => {
         expectedTxHash,
         expectedNonce,
         expectedChainId,
-        expectedIsWrapped,
+        expectedOperationType,
       );
 
       expect(signHash1).to.be.equal(
         ethers.keccak256(
           ethers.solidityPacked(
-            ["address", "uint256", "address", "bytes32", "uint256", "uint256", "bool"],
+            ["address", "uint256", "address", "bytes32", "uint256", "uint256", "uint8"],
             [
               await token.getAddress(),
               expectedAmount,
@@ -150,52 +187,114 @@ describe("ERC20Handler", () => {
               expectedTxHash,
               expectedNonce,
               expectedChainId,
-              expectedIsWrapped,
+              expectedOperationType,
             ],
           ),
         ),
       );
 
-      expect(signHash0).to.be.not.equal(signHash1);
+      expectedOperationType = ERC20BridgingType.USDCType;
+
+      let signHash2 = await handler.getERC20SignHash(
+        await token.getAddress(),
+        expectedAmount,
+        OWNER,
+        expectedTxHash,
+        expectedNonce,
+        expectedChainId,
+        expectedOperationType,
+      );
+
+      expect(signHash2).to.be.equal(
+        ethers.keccak256(
+          ethers.solidityPacked(
+            ["address", "uint256", "address", "bytes32", "uint256", "uint256", "uint8"],
+            [
+              await token.getAddress(),
+              expectedAmount,
+              OWNER.address,
+              expectedTxHash,
+              expectedNonce,
+              expectedChainId,
+              expectedOperationType,
+            ],
+          ),
+        ),
+      );
+
+      expect(signHash0).to.be.not.equal(signHash1).and.to.be.not.equal(signHash2);
     });
   });
 
   describe("withdrawERC20", () => {
-    it("should withdraw 100 tokens, is wrapped = true", async () => {
+    it("should withdraw 100 tokens, operationType = Wrapped", async () => {
       let expectedAmount = wei("100");
 
-      await handler.depositERC20(await token.getAddress(), expectedAmount, "receiver", "kovan", true);
-      await handler.withdrawERC20(await token.getAddress(), expectedAmount, OWNER, true);
+      await handler.depositERC20(
+        await token.getAddress(),
+        expectedAmount,
+        "receiver",
+        "kovan",
+        ERC20BridgingType.Wrapped,
+      );
+      await handler.withdrawERC20(await token.getAddress(), expectedAmount, OWNER, ERC20BridgingType.Wrapped);
 
       expect(await token.balanceOf(OWNER.address)).to.equal(baseBalance);
       expect(await token.balanceOf(await handler.getAddress())).to.equal(0);
     });
 
-    it("should withdraw 52 tokens, is wrapped = false", async () => {
+    it("should withdraw 52 tokens, operationType = LiquidityPool", async () => {
       let expectedAmount = wei("52");
 
-      await handler.depositERC20(await token.getAddress(), expectedAmount, "receiver", "kovan", false);
-      await handler.withdrawERC20(await token.getAddress(), expectedAmount, OWNER, false);
+      await handler.depositERC20(
+        await token.getAddress(),
+        expectedAmount,
+        "receiver",
+        "kovan",
+        ERC20BridgingType.LiquidityPool,
+      );
+      await handler.withdrawERC20(await token.getAddress(), expectedAmount, OWNER, ERC20BridgingType.LiquidityPool);
 
       expect(await token.balanceOf(OWNER.address)).to.equal(baseBalance);
       expect(await token.balanceOf(await handler.getAddress())).to.equal(0);
+    });
+
+    it("should withdraw 50 tokens, operationType = USDCType", async () => {
+      let expectedAmount = wei("50");
+
+      await handler.depositERC20(
+        await usdcTokenType.getAddress(),
+        expectedAmount,
+        "receiver",
+        "kovan",
+        ERC20BridgingType.USDCType,
+      );
+      await handler.withdrawERC20(await usdcTokenType.getAddress(), expectedAmount, OWNER, ERC20BridgingType.USDCType);
+
+      expect(await usdcTokenType.balanceOf(OWNER.address)).to.equal(baseBalance);
+      expect(await usdcTokenType.balanceOf(await handler.getAddress())).to.equal(0);
     });
 
     it("should revert when try to withdraw 0 tokens", async () => {
-      await expect(handler.withdrawERC20(await token.getAddress(), wei("0"), OWNER, false)).to.be.rejectedWith(
-        "ERC20Handler: amount is zero",
-      );
+      await expect(
+        handler.withdrawERC20(await token.getAddress(), wei("0"), OWNER, ERC20BridgingType.LiquidityPool),
+      ).to.be.rejectedWith("ERC20Handler: amount is zero");
     });
 
     it("should revert when try token address 0", async () => {
-      await expect(handler.withdrawERC20(ethers.ZeroAddress, wei("1"), OWNER, false)).to.be.rejectedWith(
-        "ERC20Handler: zero token",
-      );
+      await expect(
+        handler.withdrawERC20(ethers.ZeroAddress, wei("1"), OWNER, ERC20BridgingType.LiquidityPool),
+      ).to.be.rejectedWith("ERC20Handler: zero token");
     });
 
     it("should revert when receiver address is 0", async () => {
       await expect(
-        handler.withdrawERC20(await token.getAddress(), wei("100"), ethers.ZeroAddress, false),
+        handler.withdrawERC20(
+          await token.getAddress(),
+          wei("100"),
+          ethers.ZeroAddress,
+          ERC20BridgingType.LiquidityPool,
+        ),
       ).to.be.rejectedWith("ERC20Handler: zero receiver");
     });
   });

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -1,0 +1,15 @@
+export enum ERC20BridgingType {
+  LiquidityPool,
+  Wrapped,
+  USDCType,
+}
+
+export enum ERC721BridgingType {
+  LiquidityPool,
+  Wrapped,
+}
+
+export enum ERC1155BridgingType {
+  LiquidityPool,
+  Wrapped,
+}

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from "./reverter";
 export * from "./signature";
+export * from "./constants";


### PR DESCRIPTION
- Added BridgingType enum for all ERC-type tokens. 
- Refactored and revised documentation.
- Refactored code (Used named imports)
- Added hardhat-gobind